### PR TITLE
typo in argsPatterns regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ We can also match the methods not only by their names but also by their argument
 
     return execute(Logger).onThrowOf(execute(Authorization).before(api, {
         methodPattern: /Special|getArticleById/,
-        argsPatterns: [/^user$, /^[Ii]d(_num)?$/]
+        argsPatterns: [/^user$/, /^[Ii]d(_num)?$/]
     }));
 
 Now the aspects will be applied only to the methods which match both the `methodPattern` and `argsPatterns` rules.


### PR DESCRIPTION
In the example of before function, the first regexp give to argsPatterns miss it's ending slash.
