### PR TITLE
fix issues with bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-aop",
-  "main": "index.js",
+  "main": "./build/angular-aop.js",
   "version": "0.3.1",
   "homepage": "https://github.com/mgechev/angular-aop",
   "authors": [
@@ -22,6 +22,9 @@
     "test",
     "tests"
   ],
+  "dependencies": {
+    "angular": ">=1.2.0"
+  },
   "devDependencies": {
     "angular-mocks": "~1.2.0",
     "jasmine": "~2.2.1"


### PR DESCRIPTION
The bower.json needs a range of small fixes:

* The main file pointed to index.js. It should point to the main file which is the product of your build. 
* Furthermore the dependencies should be filled out. I assume the module requires some version of angular.

Why is it important?

The answer is that it is important for build tools, so that they can manage automatically dependencies and build me a vendor.js file by specifying all the dependencies just in bower.json

Look at:
https://github.com/ck86/main-bower-files

My gulpfile would look then 

```javascript
var gulp = require('gulp');
var mainBowerFiles = require('main-bower-files');
var gulpFilter = require('gulp-filter');
var concat = require('gulp-concat');
var sourcemaps = require('gulp-sourcemaps');

gulp.task('vendor-js',function() {
	var bower_files = mainBowerFiles();
	 var js_filter = gulpFilter(['*.js']);
	  return gulp.src(bower_files).
          pipe(debug())
	  .pipe(js_filter)
	    .pipe(sourcemaps.init())
	      .pipe(concat('vendor.js'))
	    .pipe(sourcemaps.write('.'))
	    .pipe(gulp.dest('www/lib/'));
});
```